### PR TITLE
Typo fixes, nitpicks, and `pytest.approx`

### DIFF
--- a/book/src/01_intro/01_setup.md
+++ b/book/src/01_intro/01_setup.md
@@ -38,7 +38,7 @@ You will have to modify the Rust code in the extension module to make the tests 
 Let's explore the structure of the extension module for this section.
 
 ```plaintext
-01_intro
+01_setup
 ├── sample
 ├── src
 │   └── lib.rs
@@ -179,7 +179,7 @@ Things will get a lot more interesting over the coming sections, I promise!
 
 ## Troubleshooting
 
-You may into this error when using `rye` and `pyo3` together:
+You may run into this error when using `rye` and `pyo3` together:
 
 ```plaintext
 <compiler output>

--- a/book/src/01_intro/07_exceptions.md
+++ b/book/src/01_intro/07_exceptions.md
@@ -33,7 +33,7 @@ via the `?` operator. On the Python side, this error will be raised as a Python 
 You should be intentional about the types of exceptions you raise. What kind of error are you signaling?
 What is the caller expected to catch?
 
-All built-in Python exceptions are available in `pyo3::exceptions`—e.g. `pyo3::exceptions::ValueError` for 
+All built-in Python exceptions are available in `pyo3::exceptions`—e.g. `pyo3::exceptions::PyValueError` for 
 a [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError). You can use their `new_err` 
 method to create an instance.
 

--- a/book/src/02_classes/07_outro.md
+++ b/book/src/02_classes/07_outro.md
@@ -5,5 +5,4 @@ We've covered the key concepts and most common use cases, but make sure to check
 the [official `pyo3` documentation](https://pyo3.rs/v0.22.1/class) whenever you need more information about
 a specific feature (e.g. how do I declare a class to be frozen? How do I make my class iterable?).
 
-Before moving on to the next chapter, let's take a moment to reflect on what we've learned so far
-with one last exercise.
+Let's take a moment to reflect on what we've learned so far with one last exercise.

--- a/exercises/02_classes/05_inheritance/src/lib.rs
+++ b/exercises/02_classes/05_inheritance/src/lib.rs
@@ -3,7 +3,7 @@
 //  of a `Person`.
 //  `Person` should also have a method named `full_name` that returns the full name of the person.
 //  Then define a subclass named `Employee` that inherits from `Person` and adds an
-//  `id` attribute and a constructor that sets the `id` attribute.
+//  unsigned integer `id` attribute and a constructor that sets the `id` attribute.
 //  It should be possible to access the `first_name`, `last_name` and `id`
 //  attributes of an `Employee`.
 use pyo3::prelude::*;

--- a/exercises/02_classes/06_parent/src/lib.rs
+++ b/exercises/02_classes/06_parent/src/lib.rs
@@ -1,4 +1,4 @@
-// TODO: Define a base class named `Account`, with a `balance` property.
+// TODO: Define a base class named `Account`, with a floating point `balance` property.
 //  Then define a subclass named `AccountWithHistory`.
 //  `AccountWithHistory` adds a `history` attribute: every time the `balance` is modified,
 //  the old balance is stored in the `history` list. `history` can be accessed but not modified

--- a/exercises/02_classes/07_outro/sample/tests/test_sample.py
+++ b/exercises/02_classes/07_outro/sample/tests/test_sample.py
@@ -1,29 +1,31 @@
 # Modify the Rust extension to get the test below to pass
 # Do NOT modify the test itself!
+import pytest
+
 from outro2 import Discount, CappedDiscount, SeasonalDiscount, ExpiredDiscount
 from datetime import datetime, timedelta, UTC
 
 def test_discount():
     discount = Discount(0.1)
-    assert discount.percentage == 0.1
-    assert discount.apply(100) == 90
+    assert discount.percentage == pytest.approx(0.1)
+    assert discount.apply(100) == pytest.approx(90)
 
 def test_capped_discount():
     discount = CappedDiscount(0.6, 50)
-    assert discount.percentage == 0.6
-    assert discount.cap == 50
-    assert discount.apply(100) == 50
-    assert discount.apply(50) == 20
+    assert discount.percentage == pytest.approx(0.6)
+    assert discount.cap == pytest.approx(50)
+    assert discount.apply(100) == pytest.approx(50)
+    assert discount.apply(50) == pytest.approx(20)
 
 def test_seasonal_discount():
     current = datetime.now(UTC)
     from_ = current - timedelta(days=2)
     to = current + timedelta(days=2)
     discount = SeasonalDiscount(0.1, from_, to)
-    assert discount.percentage == 0.1
+    assert discount.percentage == pytest.approx(0.1)
     assert discount.from_ == from_
     assert discount.to == to
-    assert discount.apply(100) == 90
+    assert discount.apply(100) == pytest.approx(90)
 
 # Validation tests
 def test_discount_validation():


### PR DESCRIPTION
As I was going through the course, I gathered some typo fixes and nitpicks.

Other than text tweaks, one non-trivial change I made is to the Python test file of `02_classes/07_outro`.
When comparing two floating point numbers, small precision differences can lead to unwanted assertion fails like:
```python
    def test_discount():
        discount = Discount(0.1)
>       assert discount.percentage == 0.1
E       assert 0.10000000149011612 == 0.1
```
I got this when I used `f32` for the floats instead of `f64`. But I think tests ought to pass when `f32` is used.

That's where [`pytest.approx`](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-approx) comes in:
```python
    def test_discount():
        discount = Discount(0.1)
        assert discount.percentage == pytest.approx(0.1)  # Now passes
```

It's all up to the author -- Please feel free to accept and reject individual changes as you see fit.
Thanks as always for the wonderful course.