### PR TITLE
chore(ci): add manual trigger

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    # First day of a month
+    - cron: '0 0 1 * *'
 
 jobs:
   build:


### PR DESCRIPTION
- Adds a workflow_dispatch trigger so the CI can be manually triggered
- Adds a schedule trigger to run at the beginning of each month.

Needed for one-off artifact creation for use in https://github.com/mainmatter/rust-exercises.com
We might want to consider adding a schedule too because artifacts expire after 90 days.

https://github.com/mainmatter/rust-advanced-testing-workshop could use the same config.