### PR TITLE
fix typo in 04_static_methods.md

### DIFF
--- a/book/src/02_classes/04_static_methods.md
+++ b/book/src/02_classes/04_static_methods.md
@@ -19,7 +19,7 @@ impl Wallet {
 }
 ```
 
-`Wallet::get_default` is a static method since it doesn't take `self` or references to `self` as arguments.\
+`Wallet::default` is a static method since it doesn't take `self` or references to `self` as arguments.\
 You might then expect the following to define a Python static method on the `Wallet` class:
 
 ```rust


### PR DESCRIPTION
The text referees to `Wallet::get_default` while the example code defines `Wallet::default`.