### PR TITLE
Fix typo for `threading.Thread`

### DIFF
--- a/book/src/03_concurrency/02_gil.md
+++ b/book/src/03_concurrency/02_gil.md
@@ -5,7 +5,7 @@
 On the surface, our thread-based solution addresses all the issues we identified in the `multiprocessing` module:
 
 ```python
-from threading import Process
+from threading import Thread
 from queue import Queue
 
 def word_count(text: str, n_threads: int) -> int:


### PR DESCRIPTION
Hi all :wave: This PR fixs a typo on the GIL example: it should import `threading.Thread`.