### PR TITLE
book: remove multilingual field

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Luca Palmieri (Mainmatter)"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Rust-Python interoperability"
 


### PR DESCRIPTION
It's been removed from mdbook 0.5.